### PR TITLE
Add circleci to bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,1 +1,1 @@
-
+context = [ "ci/circleci" ]


### PR DESCRIPTION
CC bors-ng/bors-ng#184

Unfortunately, bors is not smart enough to infer that circleci is enabled on your repo unless you have a circle.yml file in it. Since you're relying on Circle's ability to infer that you're using Mocha for your build harness, there's no circle.yml file here.

You need to have at least one of the two.